### PR TITLE
Fix docs layout sidebar/content stacking issue

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -75,12 +75,12 @@ layout: default
 </script>
 
 <div class="docs-container">
+  <button class="docs-sidebar-toggle" aria-label="Toggle navigation">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
   <aside class="docs-sidebar">
-    <button class="docs-sidebar-toggle" aria-label="Toggle navigation">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
     <nav class="docs-nav">
       {% for section in site.data.docs-nav %}
       <div class="docs-nav-section">

--- a/_sass/docs.scss
+++ b/_sass/docs.scss
@@ -1,9 +1,17 @@
 // Documentation layout styles
 
 .docs-container {
-  display: flex;
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap;
+  align-items: flex-start;
   min-height: calc(100vh - 80px);
   background: $background;
+  width: 100%;
+
+  @media (max-width: 767px) {
+    flex-direction: column !important;
+  }
 }
 
 // Sidebar


### PR DESCRIPTION
- Add explicit flex-direction: row to docs-container
- Add flex-wrap: nowrap to prevent wrapping
- Move sidebar toggle button outside sidebar element
- Add !important to ensure flex styles aren't overridden